### PR TITLE
Add :endpoint to the options hash for Local Storage

### DIFF
--- a/storage/index.markdown
+++ b/storage/index.markdown
@@ -158,8 +158,19 @@ While you are working out the kinks you might not want to do everything live tho
     connection = Fog::Storage.new({
       :provider   => 'Local',
       :local_root => '~/fog',
-      :endpoint   => '~/fog'
+      :endpoint   => 'http://example.com'
     })
+
+Note that `endpoint` is optional. Files will be stored in the location contained in `local_root` and if `endpoint` is present, they will have a 
+`public_url`. According to the options hash above, a file stored locally as `~/fog/pictures/kittens/gorbypuff.jpg` will have a `public_url` of 
+`http://example.com/kittens/gorbypuff.jpg` If you leave off `endpoint` from the options hash, your files will have a `public_url` of `nil` 
+
+A situation where this is useful is where you are testing an `Uploader` class in a Rails application using Local Storage. If you set 
+    
+    :endpoint => Rails.root.join 'tmp'
+
+then your files end up having a `public_url` that is a path on your filesystem under `Rails.root.join 'tmp'`. You can then 
+conveniently test methods that use `public_url` by working within your local filesystem.
 
 ## Mocking out Cloud Storage
 


### PR DESCRIPTION
If endpoint is nil, files loaded to Local Storage 
have a public_url of nil. Specifying a value for :endpoint
in the options hash fixes this.

Also please see my comment on 

https://github.com/fog/fog/commit/61ff93af32b76009651092cbd297a271b182b97e

Seeing this in the documentation would have saved me a couple of hours.

Not sure the pull request is appropriate - just thought it would make my suggested change very clear.

Thanks!
