### PR TITLE
[compute/google] Adds introduction documentation.

### DIFF
--- a/compute/index.markdown
+++ b/compute/index.markdown
@@ -113,6 +113,7 @@ Google has [Compute Engine](https://cloud.google.com/products/compute-engine). I
 
     # create a connection
     connection = Fog::Compute.new({
+      :provider => 'google',
       :google_project => GOOGLE_PROJECT_ID,
       :google_client_email => GOOGLE_SERVICE_EMAIL,
       :google_key_location => GOOGLE_KEY_LOCATION,


### PR DESCRIPTION
This adds documentation to complement fog/fog#1223.

This shouldn't be merged until it is merged.

/Nat
