### PR TITLE
Fix missing ref_id error from `jekyll build`

### DIFF
--- a/about/projects_using_fog.markdown
+++ b/about/projects_using_fog.markdown
@@ -28,7 +28,7 @@ Thanks for following these rules to keep the quality high and and the content us
 * [Engine Yard AppCloud](http://www.engineyard.com/cloud) = AWS => \[Compute, Storage\]
 * [iSwifter](http://iswifter.youwebinc.com/) = BlueBox => Compute
 * [OpenFeint](http://openfeint.com) = BlueBox => Compute
-* [PeopleAdmin](http://www.peopleadmin.com) = AWS => [Compute, Storage]
+* [PeopleAdmin](http://www.peopleadmin.com) = AWS => \[Compute, Storage\]
 * [PHPFog](https://phpfog.com) = AWS => Compute
 * [RowFeeder](https://rowfeeder.com) = Blue Box Group => Compute
 * [Viximo](http://viximo.com) = AWS => Compute


### PR DESCRIPTION
This fixes the following build error/warning:

```
$ jekyll build
Configuration file: /Users/grim/projects/fog.github.com/_config.yml
       Deprecation: Auto-regeneration can no longer be set from your configuration file(s). Use the --watch/-w command-line option instead.
       Deprecation: The 'server' configuration option is no longer accepted. Use the 'jekyll serve' subcommand to serve your site with WEBrick.
            Source: .
       Destination: ./_site
      Generating...
 ___________________________________________________________________________
| Maruku tells you:
+---------------------------------------------------------------------------
| Could not find ref_id = "compute_storage" for md_link(["Compute, Storage"],"compute_storage")
| Available refs are []
+---------------------------------------------------------------------------
!/Users/grim/.rbenv/versions/1.9.3-p385/lib/ruby/gems/1.9.1/gems/maruku-0.6.1/lib/maruku/errors_management.rb:49:in `maruku_error'
!/Users/grim/.rbenv/versions/1.9.3-p385/lib/ruby/gems/1.9.1/gems/maruku-0.6.1/lib/maruku/output/to_html.rb:716:in `to_html_link'
!/Users/grim/.rbenv/versions/1.9.3-p385/lib/ruby/gems/1.9.1/gems/maruku-0.6.1/lib/maruku/output/to_html.rb:970:in `block in array_to_html'
!/Users/grim/.rbenv/versions/1.9.3-p385/lib/ruby/gems/1.9.1/gems/maruku-0.6.1/lib/maruku/output/to_html.rb:961:in `each'
!/Users/grim/.rbenv/versions/1.9.3-p385/lib/ruby/gems/1.9.1/gems/maruku-0.6.1/lib/maruku/output/to_html.rb:961:in `array_to_html'
\___________________________________________________________________________
Not creating a link for ref_id = "compute_storage".done.
```
