### PR TITLE
Improve instructions to run tests.

### DIFF
--- a/index.markdown
+++ b/index.markdown
@@ -55,7 +55,7 @@ geemus says: "That should give you everything you need to get started, but let m
 * Fork the project and do your work in a topic branch.
   * Make sure your changes will work for the Rubies in .travis.yml (currently MRI 1.8, 1.9, and Ruby 2.0).
 * Add a config at `tests/.fog` for the component you want to test.
-* Add shindo tests to prove your code works and run all the tests using `bundle exec rake`.
+* Add shindo tests to prove your code works and run all the tests using `rake travis`.
 * Rebase your branch against `fog/fog` to make sure everything is up to date.
 * Commit your changes and send a pull request.
 


### PR DESCRIPTION
"rake" runs barely any tests:

| porridge@beczulka:~/fog$ bundle exec rake
| Run options: --seed 61633
|
| # Running:
|
| .......
|
| Finished in 0.154545s, 45.2944 runs/s, 45.2944 assertions/s.
|
| 7 runs, 7 assertions, 0 failures, 0 errors, 0 skips
| porridge@beczulka:~/fog$

I think we want developers to run shindo.
