### PR TITLE
change link of sakuracloud

### DIFF
--- a/about/provider_documentation.markdown
+++ b/about/provider_documentation.markdown
@@ -218,7 +218,7 @@ In order to maximize the benefits of open source, you are encouraged submit bugs
    </tr>
    <tr>
      <td>Sakura no Cloud</td>
-     <td><a href="https://github.com/higanworks/fog-sakuracloud/wiki/Getting-started-for-SakuraCloud">Documentation</a></td>
+     <td><a href="https://github.com/fog/fog-sakuracloud/wiki/Getting-started-for-SakuraCloud">Documentation</a></td>
      <td></td>
      <td>Community</td>
      <td></td>


### PR DESCRIPTION
Hi,

I'll divide provider sakuracloud as gem like fog-softlayer and fog-brightbox.
And then, I'll move the provider document  to gem source's wiki.  
