### PR TITLE
Update provider_documentation.markdown for OpenVZ

### DIFF
--- a/about/provider_documentation.markdown
+++ b/about/provider_documentation.markdown
@@ -196,6 +196,13 @@ In order to maximize the benefits of open source, you are encouraged submit bugs
      <td></td>
    </tr>
    <tr>
+     <td>OpenVZ</td>
+     <td></td>
+     <td></td>
+     <td>Community</td>
+     <td></td>
+   </tr>
+   <tr>
      <td>Ovirt</td>
      <td></td>
      <td></td>


### PR DESCRIPTION
Re: https://github.com/fog/fog.github.com/issues/32 - this includes OpenVZ in the documentation.

OpenVZ support has been part of the code base for more than a couple of years already!

Regards,
   Martin.
