### PR TITLE
Update Google provider docs

### DIFF
--- a/about/getting_started.markdown
+++ b/about/getting_started.markdown
@@ -60,6 +60,12 @@ Valid keys are as follows:
     <tr><td>dnsmadeeasy_secret_key</td><td></td></tr>
     <tr><td>go_grid_api_key</td><td></td></tr>
     <tr><td>go_grid_shared_secret</td><td></td></tr>
+    <tr><td>google_project</td><td>Project ID (not number)</td></tr>
+    <tr><td>google_client_email</td><td>@developer.gserviceaccount.com</td></tr>
+    <tr><td>google_key_location</td><td>Path to P12 private key (not need if using the JSON file)</td></tr>
+    <tr><td>google_key_string</td><td>In-line P12 private key string contents (alternative to specifying path)</td></tr>
+    <tr><td>google_json_key_location</td><td>Path to JSON account file (not needed if using P12 key)</td></tr>
+    <tr><td>google_json_key_string</td><td>In-line JSON private key string contents (alternative to specifying path)</td></tr>
     <tr><td>google_storage_access_key_id</td><td></td></tr>
     <tr><td>google_storage_secret_access_key</td><td></td></tr>
     <tr><td>hp_access_key</td><td></td></tr>

--- a/about/supported_services.markdown
+++ b/about/supported_services.markdown
@@ -18,7 +18,7 @@ title:  Supported Services
   <tr><th>ecloud</th><td></td><td style='text-align: center;'>+</td><td></td><td></td><td></td><td></td></tr>
   <tr><th>glesys</th><td></td><td style='text-align: center;'>+</td><td></td><td></td><td></td><td></td></tr>
   <tr><th>gogrid</th><td></td><td style='text-align: center;'>+</td><td></td><td></td><td></td><td></td></tr>
-  <tr><th>google</th><td></td><td></td><td></td><td></td><td style='text-align: center;'>+</td><td></td></tr>
+  <tr><th>google</th><td></td><td style='text-align: center;'>+</td><td style='text-align: center;'>+</td><td></td><td style='text-align: center;'>+</td><td style='text-align: center;'>monitoring, sql</td></tr>
   <tr>
     <th>hp</th>
     <td style='text-align: center;'>+</td>

--- a/compute/index.markdown
+++ b/compute/index.markdown
@@ -109,14 +109,26 @@ You can run all the same ssh commands and do what you need to, then once again s
 
 ## Google Compute Engine
 
-Google has [Compute Engine](https://cloud.google.com/products/compute-engine). To get your authorization key, visit the [Google API Console](https://code.google.com/apis/console/). Once there, go to "API Access". Click "Create another client ID..." and select "service account".
+Google has [Compute Engine](https://cloud.google.com/compute/). To get your authorization key, visit the [Google Developers Console](https://console.developers.google.com). Once there, select your project, go to "APIs & auth - Credentials". Click "Create another client ID..." and select "service account". Next, download either the JSON key (preferred) or the P12 key.
+
+If you have generated a P12 key then you will need to specify the location of your P12 key file:
 
     # create a connection
     connection = Fog::Compute.new({
       :provider => 'google',
       :google_project => GOOGLE_PROJECT_ID,
       :google_client_email => GOOGLE_SERVICE_EMAIL,
-      :google_key_location => GOOGLE_KEY_LOCATION,
+      :google_key_location => GOOGLE_P12_KEY_LOCATION,
+    })
+
+If you have generated a JSON key then then you will need to specify the location of your JSON key file:
+
+    # create a connection
+    connection = Fog::Compute.new({
+      :provider => 'google',
+      :google_project => GOOGLE_PROJECT_ID,
+      :google_client_email => GOOGLE_SERVICE_EMAIL,
+      :google_json_key_location => GOOGLE_JSON_KEY_LOCATION,
     })
 
 The easiest way to launch a server is to:


### PR DESCRIPTION
Update Google provider documentation according to https://github.com/fog/fog/issues/3413.

Also I updated some outdated Google docs (supported services and valid credentials keys).