### PR TITLE
Fixing broken links for fog-google

### DIFF
--- a/about/provider_documentation.markdown
+++ b/about/provider_documentation.markdown
@@ -127,8 +127,8 @@ In order to maximize the benefits of open source, you are encouraged submit bugs
    </tr>
    <tr>
      <td>Google</td>
-     <td><a href="https://github.com/fog/fog/blob/master/lib/fog/google/README.md">Documentation</a></td>
-     <td><a href="https://github.com/fog/fog/tree/master/lib/fog/google/examples">Examples</a></td>
+     <td><a href="https://github.com/fog/fog-google/blob/master/README.md">Documentation</a></td>
+     <td><a href="https://github.com/fog/fog-google/tree/master/examples">Examples</a></td>     
      <td>Community</td>
      <td></td>
    </tr>


### PR DESCRIPTION
Links 404 since fog-google is now a separate gem.