### PR TITLE
Fix non-breaking lines in 'Go forth and conquer' snippet

### DIFF
--- a/index.markdown
+++ b/index.markdown
@@ -37,11 +37,19 @@ Now type 'fog' to try stuff, confident that fog will let you know what to do. He
 Play around and use the console to explore or check out the [getting started guide](/about/getting_started.html) for more details. Once you are ready to start scripting fog, here is a quick hint on how to make connections without the command line thing to help you.
 
     # create a compute connection
-    compute = Fog::Compute.new({:provider => 'AWS', :aws_access_key_id => ACCESS_KEY_ID, :aws_secret_access_key => SECRET_ACCESS_KEY})
+    compute = Fog::Compute.new({
+      :provider => 'AWS',
+      :aws_access_key_id => ACCESS_KEY_ID,
+      :aws_secret_access_key => SECRET_ACCESS_KEY
+    })
     # compute operations go here
 
     # create a storage connection
-    storage = Fog::Storage.new({:provider => 'AWS', :aws_access_key_id => ACCESS_KEY_ID, :aws_secret_access_key => SECRET_ACCESS_KEY})
+    storage = Fog::Storage.new({
+      :provider => 'AWS',
+      :aws_access_key_id => ACCESS_KEY_ID,
+      :aws_secret_access_key => SECRET_ACCESS_KEY
+    })
     # storage operations go here
 
 geemus says: "That should give you everything you need to get started, but let me know if there is anything I can do to help!"


### PR DESCRIPTION
Fix for this:

![screen shot 2015-10-13 at 15 44 01](https://cloud.githubusercontent.com/assets/1774239/10458139/429ca5e8-71c1-11e5-8ccb-6cc193c96054.jpg)
