### PR TITLE
Modified reference to Ruby 1.9.3 

### DIFF
--- a/about/getting_started.markdown
+++ b/about/getting_started.markdown
@@ -5,7 +5,7 @@ title:  Getting Started
 
 ## Prerequisites
 
-Fog recommends using MRI 1.9.3 or 2.0.0.  MRI 1.8.7 and 1.9.2 are still supported by the Fog community, but are no longer supported by the Ruby community at large.  While not officially supported, Fog has been known to work with Ruby Enterprise Edition, Rubinus and JRuby.
+Fog recommends using MRI 2.0.0.  MRI 1.9.3 and 1.9.2 are still supported by the Fog community, but are no longer supported by the Ruby community at large.  While not officially supported, Fog has been known to work with Ruby Enterprise Edition, Rubinus and JRuby.
 
 ## Installation
 

--- a/about/press.markdown
+++ b/about/press.markdown
@@ -44,7 +44,7 @@ Mentions and blog posts from elsewhere in reverse chronological order by day (an
 
 **October 13, 2010**
 
-* [Engine Yard Announces Formal Support for ‘fog’ to Ensure Application Portability in the Cloud](http://www.engineyard.com/company/press/2010-10-13-engine-yard-announces-formal-support-for-%E2%80%98fog%E2%80%99-to-ensure-application-portability-in-the-cloud)
+* [Engine Yard Announces Formal Support for ‘fog’ to Ensure Application Portability in the Cloud](http://www.engineyard.com/company/$)
 * [Wesley Beary and fog Promoted to the Engine Yard Open Source Program](http://www.engineyard.com/blog/2010/wesley-beary-and-fog-promoted-to-the-engine-yard-open-source-program/)
 
 **September 28, 2010**

--- a/about/projects_using_fog.markdown
+++ b/about/projects_using_fog.markdown
@@ -29,8 +29,6 @@ Thanks for following these rules to keep the quality high and and the content us
 * [CloudForms](http://www.redhat.com/products/cloud-computing/cloudforms/) = OpenStack => \[Compute, Storage, Image, Network\]
 * [DevStructure](http://devstructure.com/) = AWS => Compute, Rackspace => Compute, Slicehost => Compute
 * [Engine Yard AppCloud](http://www.engineyard.com/cloud) = AWS => \[Compute, Storage\]
-* [iSwifter](http://iswifter.youwebinc.com/) = BlueBox => Compute
-* [OpenFeint](http://openfeint.com) = BlueBox => Compute
 * [PeopleAdmin](http://www.peopleadmin.com) = AWS => \[Compute, Storage\]
 * [PHPFog](https://phpfog.com) = AWS => Compute
 * [RowFeeder](https://rowfeeder.com) = Blue Box Group => Compute

--- a/index.markdown
+++ b/index.markdown
@@ -13,7 +13,7 @@ With a rapidly expanding community and codebase the advantages of fog just keep 
 
 ## Prerequisites
 
-Fog recommends using MRI 1.9.3 or 2.0.0.  MRI 1.8.7 and 1.9.2 are still supported by the Fog community, but are no longer supported by the Ruby community at large.  While not officially supported, Fog has been known to work with Ruby Enterprise Edition, Rubinus and JRuby.
+Fog recommends using MRI 2.0.0.  MRI 1.9.3 and 1.9.2 are still supported by the Fog community, but are no longer supported by the Ruby community at large.  While not officially supported, Fog has been known to work with Ruby Enterprise Edition, Rubinus and JRuby.
 
 ## Quick Start
 

--- a/storage/index.markdown
+++ b/storage/index.markdown
@@ -127,7 +127,7 @@ More clouds? How much extra stuff will you have to do for these services!?! Hard
 
 ## Google Cloud Storage
 
-Sign up <a href="http://gs-signup-redirect.appspot.com/">here</a> and get your credentials <a href="https://storage.cloud.google.com/m">here</a> under the section "Interoperable Access".
+Sign up <a href="https://cloud.google.com/storage/docs/signup?hl=en">here</a> and get your credentials <a href="https://storage.cloud.google.com/m">here</a> under the section "Interoperable Access".
 
     connection = Fog::Storage.new({
       :provider                         => 'Google',


### PR DESCRIPTION
Modified referenced to Ruby 1.9.3 was mentioned as still being supported. Removed and/or fixed dead hyperlinks.
