### PR TITLE
Removing HP from documentation

### DIFF
--- a/about/getting_started.markdown
+++ b/about/getting_started.markdown
@@ -22,13 +22,13 @@ Fog will continue to search for credentials in the following order until found:
 
 
 This is an example of a ```.fog``` file:
- 
+
 	default:
 	    rackspace_username: RACKSPACE_USERNAME
 	    rackspace_api_key: RACKSPACE_API_KEY
 	    public_key_path: ~/.ssh/fog_rsa.pub
 	    private_key_path: ~/.ssh/fog_rsa
-	
+
 	provider2:
 		provider_username: USERNAME
 		provider_api_key: API_KEY
@@ -68,9 +68,6 @@ Valid keys are as follows:
     <tr><td>google_json_key_string</td><td>In-line JSON private key string contents (alternative to specifying path)</td></tr>
     <tr><td>google_storage_access_key_id</td><td></td></tr>
     <tr><td>google_storage_secret_access_key</td><td></td></tr>
-    <tr><td>hp_access_key</td><td></td></tr>
-    <tr><td>hp_secret_key</td><td></td></tr>
-    <tr><td>hp_tenant_id</td><td></td></tr>
     <tr><td>ibm_password</td><td></td></tr>
     <tr><td>ibm_username</td><td></td></tr>
     <tr><td>libvirt_ip_command</td><td></td></tr>

--- a/about/provider_documentation.markdown
+++ b/about/provider_documentation.markdown
@@ -142,15 +142,15 @@ In order to maximize the benefits of open source, you are encouraged submit bugs
    <tr>
      <td>Google</td>
      <td><a href="https://github.com/fog/fog-google/blob/master/README.md">Documentation</a></td>
-     <td><a href="https://github.com/fog/fog-google/tree/master/examples">Examples</a></td>     
+     <td><a href="https://github.com/fog/fog-google/tree/master/examples">Examples</a></td>
      <td>Community</td>
      <td></td>
    </tr>
    <tr>
      <td>HP</td>
-     <td><a href="https://github.com/fog/fog/blob/master/lib/fog/hp/README.md">Documentation</a></td>
-     <td><a href="https://github.com/fog/fog/blob/master/lib/fog/hp/examples/getting_started_examples.md">Examples</a></td>
-     <td>Community</td>
+     <td>HP Cloud has been decommissioned and removed as of March 1, 2016. </td>
+     <td></td>
+     <td>None</td>
      <td></td>
    </tr>
    <tr>

--- a/about/supported_services.markdown
+++ b/about/supported_services.markdown
@@ -19,16 +19,6 @@ title:  Supported Services
   <tr><th>glesys</th><td></td><td style='text-align: center;'>+</td><td></td><td></td><td></td><td></td></tr>
   <tr><th>gogrid</th><td></td><td style='text-align: center;'>+</td><td></td><td></td><td></td><td></td></tr>
   <tr><th>google</th><td></td><td style='text-align: center;'>+</td><td style='text-align: center;'>+</td><td></td><td style='text-align: center;'>+</td><td style='text-align: center;'>monitoring, sql</td></tr>
-  <tr>
-    <th>hp</th>
-    <td style='text-align: center;'>+</td>
-    <td style='text-align: center;'>+</td>
-    <td style='text-align: center;'>+</td>
-    <td></td>
-    <td style='text-align: center;'>+</td>
-    <td style='text-align: center;'>network, block_storage, block_storage_v2,
-     compute_v2, dns, load_balancer</td>
-  </tr>
   <tr><th>ibm</th><td></td><td style='text-align: center;'>+</td><td></td><td></td><td style='text-align: center;'>+</td><td></td></tr>
   <tr><th>joyent</th><td></td><td style='text-align: center;'>+</td><td></td><td></td><td></td><td></td></tr>
   <tr><th>libvirt</th><td></td><td style='text-align: center;'>+</td><td></td><td></td><td></td><td></td></tr>


### PR DESCRIPTION
- This removes and makes note of the HP Public cloud being shutdown.