### PR TITLE
Changes preformatted code blocks to use left-align text for readability

### DIFF
--- a/public/css/fog.css
+++ b/public/css/fog.css
@@ -129,6 +129,7 @@ pre {
   border-radius: 0.5em;
   margin: 1em;
   white-space: pre;
+  text-align: left;
 }
 
 pre code {


### PR DESCRIPTION
This fixes center text-alignment in code snippets, which is hard to read.

### Before

<img width="792" alt="screen shot 2017-02-21 at 10 06 05 pm" src="https://cloud.githubusercontent.com/assets/2567135/23195469/bb50cc2e-f881-11e6-9efa-02df95d6d651.png">

### After

<img width="786" alt="screen shot 2017-02-21 at 10 06 23 pm" src="https://cloud.githubusercontent.com/assets/2567135/23195486/d5267284-f881-11e6-8000-ff280523c6a8.png">

