### PR TITLE
Remove line numbers from code blocks to fix formatting

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,8 +23,7 @@ kramdown:
   syntax_highlighter_opts:
     block:
       wrap: div
-      line_numbers: inline
-      line_numbers_start: 1
+      line_numbers: false
       tab_width: 4
       bold_every: 10
       css: style


### PR DESCRIPTION
I wasn't able to figure out how to fix styles so we don't have the line number artifacts, but this is IMO an acceptable fix until someone can redesign the website again.

Before:
<img width="788" alt="Screen Shot 2019-03-22 at 8 26 03 pm" src="https://user-images.githubusercontent.com/2083229/54813062-c4d21b80-4ce0-11e9-9a63-e1bd77e3d832.png">

After:
<img width="789" alt="Screen Shot 2019-03-22 at 8 23 12 pm" src="https://user-images.githubusercontent.com/2083229/54812898-5d1bd080-4ce0-11e9-8880-ce48ae9833b6.png">
